### PR TITLE
Add missing x64 configuration for api and model projects

### DIFF
--- a/src/Sierra.Api/Sierra.Api.csproj
+++ b/src/Sierra.Api/Sierra.Api.csproj
@@ -4,13 +4,22 @@
     <TargetFramework>net462</TargetFramework>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <IsServiceFabricServiceProject>True</IsServiceFabricServiceProject>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\net462\win7-x64\Sierra.Api.xml</DocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DocumentationFile>bin\Debug\net462\win7-x64\Sierra.Api.xml</DocumentationFile>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\net462\win7-x64\Sierra.Api.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DocumentationFile>bin\Release\net462\win7-x64\Sierra.Api.xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/Sierra.Model/Sierra.Model.csproj
+++ b/src/Sierra.Model/Sierra.Model.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,14 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/Sierra.sln
+++ b/src/Sierra.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{A07B5EB6-E848-4116-A8D0-A826331D98C6}") = "Sierra.Fabric", "Sierra.Fabric\Sierra.Fabric.sfproj", "{17909DD2-D384-4E32-9904-1387B726B2D2}"
 EndProject
@@ -47,8 +47,8 @@ Global
 		{17909DD2-D384-4E32-9904-1387B726B2D2}.Release|x64.Deploy.0 = Release|x64
 		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|x64.ActiveCfg = Debug|x64
+		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Debug|x64.Build.0 = Debug|x64
 		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D0FC4E35-7650-49AD-B5A8-67539A936712}.Release|x64.ActiveCfg = Release|Any CPU
@@ -67,8 +67,8 @@ Global
 		{88F35AE9-9157-4EB7-A873-9AA687263FA8}.Release|x64.Build.0 = Release|x64
 		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|x64.ActiveCfg = Debug|x64
+		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Debug|x64.Build.0 = Debug|x64
 		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6F357D26-DB46-4232-B5A8-6007764C0CF4}.Release|x64.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Add in x64 configuration for the api and the model and update their default platform so that we can package sierra