### PR TITLE
Fixed port sharing issues

### DIFF
--- a/src/Sierra.Api/PackageRoot/ServiceManifest.xml
+++ b/src/Sierra.Api/PackageRoot/ServiceManifest.xml
@@ -32,7 +32,7 @@
       <!-- This endpoint is used by the communication listener to obtain the port on which to 
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
-      <Endpoint Protocol="http" Name="SierraApiEndpoint" Type="Input" Port="9500" />
+      <Endpoint Protocol="http" Name="SierraApiEndpoint" Type="Input" />
     </Endpoints>
   </Resources>
 </ServiceManifest>


### PR DESCRIPTION
The explicitly defined port of an endpoint causes issues e.g. when the local SF cluster is configured to use 5 nodes. Without this configuration value ports will be assigned dynamically. The application can be reached using the reverse proxy (e.g. http://localhost:19081/Sierra.ServiceFabric/SierraApi/) or directly using the address provided by SF Explorer.